### PR TITLE
SL-3282 Webp - do not attempt to build unrecognised color model

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.twelvemonkeys</groupId>
         <artifactId>twelvemonkeys</artifactId>
-        <version>3.10.0-SNAPSHOT</version>
+        <version>3.10.0-EBX-SNAPSHOT</version>
     </parent>
 
     <groupId>com.twelvemonkeys.bom</groupId>

--- a/common/common-image/pom.xml
+++ b/common/common-image/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.twelvemonkeys.common</groupId>
         <artifactId>common</artifactId>
-        <version>3.10.0-SNAPSHOT</version>
+        <version>3.10.0-EBX-SNAPSHOT</version>
     </parent>
     <artifactId>common-image</artifactId>
     <packaging>jar</packaging>

--- a/common/common-io/pom.xml
+++ b/common/common-io/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.twelvemonkeys.common</groupId>
         <artifactId>common</artifactId>
-        <version>3.10.0-SNAPSHOT</version>
+        <version>3.10.0-EBX-SNAPSHOT</version>
     </parent>
     <artifactId>common-io</artifactId>
     <packaging>jar</packaging>

--- a/common/common-lang/pom.xml
+++ b/common/common-lang/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.twelvemonkeys.common</groupId>
         <artifactId>common</artifactId>
-        <version>3.10.0-SNAPSHOT</version>
+        <version>3.10.0-EBX-SNAPSHOT</version>
     </parent>
     <artifactId>common-lang</artifactId>
     <packaging>jar</packaging>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.twelvemonkeys</groupId>
         <artifactId>twelvemonkeys</artifactId>
-        <version>3.10.0-SNAPSHOT</version>
+        <version>3.10.0-EBX-SNAPSHOT</version>
     </parent>
     <groupId>com.twelvemonkeys.common</groupId>
     <artifactId>common</artifactId>

--- a/contrib/pom.xml
+++ b/contrib/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.twelvemonkeys</groupId>
         <artifactId>twelvemonkeys</artifactId>
-        <version>3.10.0-SNAPSHOT</version>
+        <version>3.10.0-EBX-SNAPSHOT</version>
     </parent>
     <groupId>com.twelvemonkeys.contrib</groupId>
     <artifactId>contrib</artifactId>

--- a/imageio/imageio-batik/pom.xml
+++ b/imageio/imageio-batik/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.twelvemonkeys.imageio</groupId>
         <artifactId>imageio</artifactId>
-        <version>3.10.0-SNAPSHOT</version>
+        <version>3.10.0-EBX-SNAPSHOT</version>
     </parent>
     <artifactId>imageio-batik</artifactId>
     <name>TwelveMonkeys :: ImageIO :: Batik Plugin</name>

--- a/imageio/imageio-bmp/pom.xml
+++ b/imageio/imageio-bmp/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.twelvemonkeys.imageio</groupId>
         <artifactId>imageio</artifactId>
-        <version>3.10.0-SNAPSHOT</version>
+        <version>3.10.0-EBX-SNAPSHOT</version>
     </parent>
     <artifactId>imageio-bmp</artifactId>
     <name>TwelveMonkeys :: ImageIO :: BMP plugin</name>

--- a/imageio/imageio-clippath/pom.xml
+++ b/imageio/imageio-clippath/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.twelvemonkeys.imageio</groupId>
         <artifactId>imageio</artifactId>
-        <version>3.10.0-SNAPSHOT</version>
+        <version>3.10.0-EBX-SNAPSHOT</version>
     </parent>
     <artifactId>imageio-clippath</artifactId>
     <name>TwelveMonkeys :: ImageIO :: Photoshop Path Support</name>

--- a/imageio/imageio-core/pom.xml
+++ b/imageio/imageio-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.twelvemonkeys.imageio</groupId>
         <artifactId>imageio</artifactId>
-        <version>3.10.0-SNAPSHOT</version>
+        <version>3.10.0-EBX-SNAPSHOT</version>
     </parent>
     <artifactId>imageio-core</artifactId>
     <name>TwelveMonkeys :: ImageIO :: Core</name>

--- a/imageio/imageio-hdr/pom.xml
+++ b/imageio/imageio-hdr/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.twelvemonkeys.imageio</groupId>
         <artifactId>imageio</artifactId>
-        <version>3.10.0-SNAPSHOT</version>
+        <version>3.10.0-EBX-SNAPSHOT</version>
     </parent>
     <artifactId>imageio-hdr</artifactId>
     <name>TwelveMonkeys :: ImageIO :: HDR plugin</name>

--- a/imageio/imageio-icns/pom.xml
+++ b/imageio/imageio-icns/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.twelvemonkeys.imageio</groupId>
         <artifactId>imageio</artifactId>
-        <version>3.10.0-SNAPSHOT</version>
+        <version>3.10.0-EBX-SNAPSHOT</version>
     </parent>
     <artifactId>imageio-icns</artifactId>
     <name>TwelveMonkeys :: ImageIO :: ICNS plugin</name>

--- a/imageio/imageio-iff/pom.xml
+++ b/imageio/imageio-iff/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.twelvemonkeys.imageio</groupId>
         <artifactId>imageio</artifactId>
-        <version>3.10.0-SNAPSHOT</version>
+        <version>3.10.0-EBX-SNAPSHOT</version>
     </parent>
     <artifactId>imageio-iff</artifactId>
     <name>TwelveMonkeys :: ImageIO :: IFF plugin</name>

--- a/imageio/imageio-jpeg-jai-interop/pom.xml
+++ b/imageio/imageio-jpeg-jai-interop/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.twelvemonkeys.imageio</groupId>
         <artifactId>imageio</artifactId>
-        <version>3.10.0-SNAPSHOT</version>
+        <version>3.10.0-EBX-SNAPSHOT</version>
     </parent>
     <artifactId>imageio-jpeg-jai-interop</artifactId>
     <name>TwelveMonkeys :: ImageIO :: JPEG/JAI TIFF Interop</name>

--- a/imageio/imageio-jpeg-jep262-interop/pom.xml
+++ b/imageio/imageio-jpeg-jep262-interop/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.twelvemonkeys.imageio</groupId>
         <artifactId>imageio</artifactId>
-        <version>3.10.0-SNAPSHOT</version>
+        <version>3.10.0-EBX-SNAPSHOT</version>
     </parent>
     <artifactId>imageio-jpeg-jep262-interop</artifactId>
     <name>TwelveMonkeys :: ImageIO :: JPEG/JEP-262 Interop</name>

--- a/imageio/imageio-jpeg/pom.xml
+++ b/imageio/imageio-jpeg/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.twelvemonkeys.imageio</groupId>
         <artifactId>imageio</artifactId>
-        <version>3.10.0-SNAPSHOT</version>
+        <version>3.10.0-EBX-SNAPSHOT</version>
     </parent>
     <artifactId>imageio-jpeg</artifactId>
     <name>TwelveMonkeys :: ImageIO :: JPEG plugin</name>

--- a/imageio/imageio-metadata/pom.xml
+++ b/imageio/imageio-metadata/pom.xml
@@ -3,7 +3,7 @@
     <parent>
 	<groupId>com.twelvemonkeys.imageio</groupId>
 	<artifactId>imageio</artifactId>        
-        <version>3.10.0-SNAPSHOT</version>
+        <version>3.10.0-EBX-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>imageio-metadata</artifactId>

--- a/imageio/imageio-pcx/pom.xml
+++ b/imageio/imageio-pcx/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.twelvemonkeys.imageio</groupId>
         <artifactId>imageio</artifactId>
-        <version>3.10.0-SNAPSHOT</version>
+        <version>3.10.0-EBX-SNAPSHOT</version>
     </parent>
     <artifactId>imageio-pcx</artifactId>
     <name>TwelveMonkeys :: ImageIO :: PCX plugin</name>

--- a/imageio/imageio-pdf/pom.xml
+++ b/imageio/imageio-pdf/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.twelvemonkeys.imageio</groupId>
         <artifactId>imageio</artifactId>
-        <version>3.10.0-SNAPSHOT</version>
+        <version>3.10.0-EBX-SNAPSHOT</version>
     </parent>
     <artifactId>imageio-pdf</artifactId>
     <name>TwelveMonkeys :: ImageIO :: PDF plugin</name>

--- a/imageio/imageio-pict/pom.xml
+++ b/imageio/imageio-pict/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.twelvemonkeys.imageio</groupId>
         <artifactId>imageio</artifactId>
-        <version>3.10.0-SNAPSHOT</version>
+        <version>3.10.0-EBX-SNAPSHOT</version>
     </parent>
     <artifactId>imageio-pict</artifactId>
     <name>TwelveMonkeys :: ImageIO :: PICT plugin</name>

--- a/imageio/imageio-pnm/pom.xml
+++ b/imageio/imageio-pnm/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.twelvemonkeys.imageio</groupId>
         <artifactId>imageio</artifactId>
-        <version>3.10.0-SNAPSHOT</version>
+        <version>3.10.0-EBX-SNAPSHOT</version>
     </parent>
     <artifactId>imageio-pnm</artifactId>
     <name>TwelveMonkeys :: ImageIO :: PNM plugin</name>

--- a/imageio/imageio-psd/pom.xml
+++ b/imageio/imageio-psd/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.twelvemonkeys.imageio</groupId>
         <artifactId>imageio</artifactId>
-        <version>3.10.0-SNAPSHOT</version>
+        <version>3.10.0-EBX-SNAPSHOT</version>
     </parent>
     <artifactId>imageio-psd</artifactId>
     <name>TwelveMonkeys :: ImageIO :: PSD plugin</name>

--- a/imageio/imageio-reference/pom.xml
+++ b/imageio/imageio-reference/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.twelvemonkeys.imageio</groupId>
         <artifactId>imageio</artifactId>
-        <version>3.10.0-SNAPSHOT</version>
+        <version>3.10.0-EBX-SNAPSHOT</version>
     </parent>
     <artifactId>imageio-reference</artifactId>
     <name>TwelveMonkeys :: ImageIO :: JDK Reference Tests</name>

--- a/imageio/imageio-sgi/pom.xml
+++ b/imageio/imageio-sgi/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.twelvemonkeys.imageio</groupId>
         <artifactId>imageio</artifactId>
-        <version>3.10.0-SNAPSHOT</version>
+        <version>3.10.0-EBX-SNAPSHOT</version>
     </parent>
     <artifactId>imageio-sgi</artifactId>
     <name>TwelveMonkeys :: ImageIO :: SGI plugin</name>

--- a/imageio/imageio-tga/pom.xml
+++ b/imageio/imageio-tga/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.twelvemonkeys.imageio</groupId>
         <artifactId>imageio</artifactId>
-        <version>3.10.0-SNAPSHOT</version>
+        <version>3.10.0-EBX-SNAPSHOT</version>
     </parent>
     <artifactId>imageio-tga</artifactId>
     <name>TwelveMonkeys :: ImageIO :: TGA plugin</name>

--- a/imageio/imageio-thumbsdb/pom.xml
+++ b/imageio/imageio-thumbsdb/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.twelvemonkeys.imageio</groupId>
         <artifactId>imageio</artifactId>
-        <version>3.10.0-SNAPSHOT</version>
+        <version>3.10.0-EBX-SNAPSHOT</version>
     </parent>
     <artifactId>imageio-thumbsdb</artifactId>
     <name>TwelveMonkeys :: ImageIO :: Thumbs.db plugin</name>

--- a/imageio/imageio-tiff-jai-interop/pom.xml
+++ b/imageio/imageio-tiff-jai-interop/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.twelvemonkeys.imageio</groupId>
         <artifactId>imageio</artifactId>
-        <version>3.10.0-SNAPSHOT</version>
+        <version>3.10.0-EBX-SNAPSHOT</version>
     </parent>
     <artifactId>imageio-tiff-jai-interop</artifactId>
     <name>TwelveMonkeys :: ImageIO :: TIFF/JAI Metadata Interop</name>

--- a/imageio/imageio-tiff-jdk-interop/pom.xml
+++ b/imageio/imageio-tiff-jdk-interop/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.twelvemonkeys.imageio</groupId>
         <artifactId>imageio</artifactId>
-        <version>3.10.0-SNAPSHOT</version>
+        <version>3.10.0-EBX-SNAPSHOT</version>
     </parent>
     <artifactId>imageio-tiff-jdk-interop</artifactId>
     <name>TwelveMonkeys :: ImageIO :: TIFF/JDK JPEG Interop</name>

--- a/imageio/imageio-tiff/pom.xml
+++ b/imageio/imageio-tiff/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.twelvemonkeys.imageio</groupId>
         <artifactId>imageio</artifactId>
-        <version>3.10.0-SNAPSHOT</version>
+        <version>3.10.0-EBX-SNAPSHOT</version>
     </parent>
     <artifactId>imageio-tiff</artifactId>
     <name>TwelveMonkeys :: ImageIO :: TIFF plugin</name>

--- a/imageio/imageio-webp/pom.xml
+++ b/imageio/imageio-webp/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.twelvemonkeys.imageio</groupId>
         <artifactId>imageio</artifactId>
-        <version>3.10.0-SNAPSHOT</version>
+        <version>3.10.0-EBX-SNAPSHOT</version>
     </parent>
     <artifactId>imageio-webp</artifactId>
     <name>TwelveMonkeys :: ImageIO :: WebP plugin</name>

--- a/imageio/imageio-webp/src/main/java/com/twelvemonkeys/imageio/plugins/webp/WebPImageReader.java
+++ b/imageio/imageio-webp/src/main/java/com/twelvemonkeys/imageio/plugins/webp/WebPImageReader.java
@@ -304,7 +304,19 @@ final class WebPImageReader extends ImageReaderBase {
                         long chunkStart = imageInput.getStreamPosition();
 
                         if (nextChunk == WebP.CHUNK_ICCP) {
-                            iccProfile = ColorProfiles.readProfile(IIOUtil.createStreamAdapter(imageInput, chunkLength));
+                            ICC_Profile iccProfile =
+                                ColorProfiles.readProfile(IIOUtil.createStreamAdapter(imageInput, chunkLength));
+                            
+                            if (iccProfile.getData() == ICC_Profile.getInstance(ColorSpace.CS_sRGB).getData()
+                                ||iccProfile.getData() == ICC_Profile.getInstance(ColorSpace.CS_GRAY).getData()
+                                ||iccProfile.getData() == ICC_Profile.getInstance(ColorSpace.CS_PYCC).getData()
+                                ||iccProfile.getData() == ICC_Profile.getInstance(ColorSpace.CS_LINEAR_RGB).getData()
+                                ||iccProfile.getData() == ICC_Profile.getInstance(ColorSpace.CS_CIEXYZ).getData()) {
+                                this.iccProfile = iccProfile;
+                            } else {
+                                throw new IllegalStateException("ICC profile not matching "
+                                    + "recognised lists");
+                            }
                         }
                         else {
                             processWarningOccurred(String.format("Expected 'ICCP' chunk, '%s' chunk encountered", fourCC(nextChunk)));

--- a/imageio/imageio-xwd/pom.xml
+++ b/imageio/imageio-xwd/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.twelvemonkeys.imageio</groupId>
         <artifactId>imageio</artifactId>
-        <version>3.10.0-SNAPSHOT</version>
+        <version>3.10.0-EBX-SNAPSHOT</version>
     </parent>
     <artifactId>imageio-xwd</artifactId>
     <name>TwelveMonkeys :: ImageIO :: XWD plugin</name>

--- a/imageio/pom.xml
+++ b/imageio/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.twelvemonkeys</groupId>
         <artifactId>twelvemonkeys</artifactId>
-        <version>3.10.0-SNAPSHOT</version>
+        <version>3.10.0-EBX-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.twelvemonkeys.imageio</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.twelvemonkeys</groupId>
     <artifactId>twelvemonkeys</artifactId>
-    <version>3.10.0-SNAPSHOT</version>
+    <version>3.10.0-EBX-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>TwelveMonkeys</name>
     <description>TwelveMonkeys parent POM</description>

--- a/servlet/pom.xml
+++ b/servlet/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.twelvemonkeys</groupId>
         <artifactId>twelvemonkeys</artifactId>
-        <version>3.10.0-SNAPSHOT</version>
+        <version>3.10.0-EBX-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
This avoids unexpected issues which are undetected where color models cause the image to become a different colour such as green.